### PR TITLE
Don't split menus across files, fixes #6

### DIFF
--- a/CCScriptWriter/CCScriptWriter.py
+++ b/CCScriptWriter/CCScriptWriter.py
@@ -455,6 +455,8 @@ class CCScriptWriter:
         block = ""
         start = i
         text = False
+        normal_block_expect_02 = False
+
         while True:
             if stop and stop == i:
                 break
@@ -471,6 +473,10 @@ class CCScriptWriter:
                         length = self.getLength(i)
                     block += "[{}".format(FormatHex(c))
 
+                    # Mark if we expect an [02] before the end of the block
+                    if c == 0x19:
+                        normal_block_expect_02 = True
+
                     # Get the rest of the control code.
                     codeEnd = i + length
                     while i < codeEnd:
@@ -479,7 +485,10 @@ class CCScriptWriter:
                     block += "]"
 
                     # Stop if this is a block-ending character.
-                    if c == 0x02 or c == 0x0A:
+                    if c == 0x02 and normal_block_expect_02:
+                        # But don't stop if we expect an [02] that doesn't end the block
+                        normal_block_expect_02 = False
+                    elif c == 0x02 or c == 0x0A:
                         break
                 # Check if it's a special character.
                 elif c == 0x52 or c == 0x8b or c == 0x8c or c == 0x8d:


### PR DESCRIPTION
Issue #6 was being caused by the setup of a menu being separated across multiple files. The setup of a menu takes the form of:

```
[19 02]Option A[02 19 02]Option B[02 1C 07 02 11 09 02 AA AA AA 00 BB BB BB 00]@Cancel text[02]
```

The `[02]` after "Option A" and "Option B" was being interpreted by CCScriptWriter as the `[02]` which marks the end of a block, letting CCScriptWriter think it could split this code across files. When that happened, the code was written non-adjacently in the ROM, causing problems. I've modified CCScriptWriter to recognize that if a `[02]` follows a `[19 XX]`, it does not mark the end of a block.